### PR TITLE
Validate Project Requests on Create/Update

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   # Duplicated from pull request workflow because sharing is not yet supported
   build-docker:
+    name: Build Docker Image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -57,12 +58,16 @@ jobs:
           IMAGE_NAME=${{ github.event.repository.name }} IMAGE=lyft/${{ github.event.repository.name }}:latest make end2end_execute
 
   bump-version:
+    name: Bump Version
     if: github.actor != 'goreleaserbot'
     runs-on: ubuntu-latest
     needs: build-docker # Only to ensure it can successfully build
     outputs:
       version: ${{ steps.bump-version.outputs.tag }}
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
       - name: Bump version and push tag
         id: bump-version
         uses: anothrNick/github-tag-action@1.17.2
@@ -72,6 +77,7 @@ jobs:
           DEFAULT_BUMP: patch
 
   goreleaser:
+    name: Goreleaser
     runs-on: ubuntu-latest
     needs: [bump-version]
     steps:
@@ -91,6 +97,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}
 
   push-github:
+    name: Push to Github Registry
     runs-on: ubuntu-latest
     needs: bump-version
     steps:
@@ -109,6 +116,7 @@ jobs:
           build_extra_args: "--compress=true"
 
   push-dockerhub:
+    name: Push to Dockerhub
     runs-on: ubuntu-latest
     needs: bump-version
     steps:
@@ -126,6 +134,7 @@ jobs:
           build_extra_args: "--compress=true"
 
   tests-lint:
+    name: Run tests and lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -71,7 +71,26 @@ jobs:
           WITH_V: true
           DEFAULT_BUMP: patch
 
-  push-github-end2end:
+  goreleaser:
+    runs-on: ubuntu-latest
+    needs: [bump-version]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}
+
+  push-github:
     runs-on: ubuntu-latest
     needs: bump-version
     steps:
@@ -83,7 +102,7 @@ jobs:
         with:
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
-          image_name: ${{ github.repository }}
+          image_name: ${{ github.repository }}/${{ github.event.repository.name }}
           image_tag: latest,${{ github.sha }},${{ needs.bump-version.outputs.version }}
           push_git_tag: true
           registry: docker.pkg.github.com

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   build-docker:
+    name: Build Docker Image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -53,6 +54,7 @@ jobs:
           IMAGE_NAME=${{ github.event.repository.name }} IMAGE=lyft/${{ github.event.repository.name }}:latest make end2end_execute
 
   integration:
+    name: Integration tests
     runs-on: ubuntu-latest
     needs: [build-docker]
     steps:
@@ -76,6 +78,7 @@ jobs:
           IMAGE_NAME=${{ github.event.repository.name }} IMAGE=lyft/${{ github.event.repository.name }}:builder make k8s_integration_execute
 
   tests-lint:
+    name: Run tests and lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
 archives:
   - id: flyteadmin-archive
     name_template: |-
-      kyverno-cli_{{ .Tag }}_{{ .Os }}_{{ .Arch -}}
+      flyteadmin_{{ .Tag }}_{{ .Os }}_{{ .Arch -}}
       {{- with .Arm -}}
       {{- if (eq . "6") -}}hf
       {{- else -}}v{{- . -}}

--- a/boilerplate/lyft/github_workflows/master.yml
+++ b/boilerplate/lyft/github_workflows/master.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   # Duplicated from pull request workflow because sharing is not yet supported
   build-docker:
+    name: Build Docker Image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -57,12 +58,16 @@ jobs:
           IMAGE_NAME=${{ github.event.repository.name }} IMAGE=lyft/${{ github.event.repository.name }}:latest make end2end_execute
 
   bump-version:
+    name: Bump Version
     if: github.actor != 'goreleaserbot'
     runs-on: ubuntu-latest
     needs: build-docker # Only to ensure it can successfully build
     outputs:
       version: ${{ steps.bump-version.outputs.tag }}
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
       - name: Bump version and push tag
         id: bump-version
         uses: anothrNick/github-tag-action@1.17.2
@@ -71,7 +76,28 @@ jobs:
           WITH_V: true
           DEFAULT_BUMP: patch
 
-  push-github-end2end:
+  goreleaser:
+    name: Goreleaser
+    runs-on: ubuntu-latest
+    needs: [bump-version]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}
+
+  push-github:
+    name: Push to Github Registry
     runs-on: ubuntu-latest
     needs: bump-version
     steps:
@@ -83,13 +109,14 @@ jobs:
         with:
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
-          image_name: ${{ github.repository }}
+          image_name: ${{ github.repository }}/${{ github.event.repository.name }}
           image_tag: latest,${{ github.sha }},${{ needs.bump-version.outputs.version }}
           push_git_tag: true
           registry: docker.pkg.github.com
           build_extra_args: "--compress=true"
 
   push-dockerhub:
+    name: Push to Dockerhub
     runs-on: ubuntu-latest
     needs: bump-version
     steps:
@@ -107,6 +134,7 @@ jobs:
           build_extra_args: "--compress=true"
 
   tests-lint:
+    name: Run tests and lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/boilerplate/lyft/github_workflows/pull_request.yml
+++ b/boilerplate/lyft/github_workflows/pull_request.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   build-docker:
+    name: Build Docker Image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -53,6 +54,7 @@ jobs:
           IMAGE_NAME=${{ github.event.repository.name }} IMAGE=lyft/${{ github.event.repository.name }}:latest make end2end_execute
 
   integration:
+    name: Integration tests
     runs-on: ubuntu-latest
     needs: [build-docker]
     steps:
@@ -76,6 +78,7 @@ jobs:
           IMAGE_NAME=${{ github.event.repository.name }} IMAGE=lyft/${{ github.event.repository.name }}:builder make k8s_integration_execute
 
   tests-lint:
+    name: Run tests and lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/cmd/entrypoints/serve.go
+++ b/cmd/entrypoints/serve.go
@@ -212,7 +212,8 @@ func serveGatewayInsecure(ctx context.Context, cfg *config.ServerConfig) error {
 	}()
 
 	logger.Infof(ctx, "Starting HTTP/1 Gateway server on %s", cfg.GetHostAddress())
-	httpServer, err := newHTTPServer(ctx, cfg, authContext, cfg.GetGrpcHostAddress(), grpc.WithInsecure())
+	httpServer, err := newHTTPServer(ctx, cfg, authContext, cfg.GetGrpcHostAddress(), grpc.WithInsecure(),
+		grpc.WithMaxHeaderListSize(common.MaxResponseStatusBytes))
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/jinzhu/gorm v1.9.12
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/lib/pq v1.3.0
-	github.com/lyft/flyteidl v0.18.6
+	github.com/lyft/flyteidl v0.18.10
 	github.com/lyft/flytepropeller v0.3.17
 	github.com/lyft/flytestdlib v0.3.9
 	github.com/magiconair/properties v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -464,6 +464,8 @@ github.com/lyft/flyteidl v0.17.0/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/
 github.com/lyft/flyteidl v0.18.0/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
 github.com/lyft/flyteidl v0.18.6 h1:HGbxHI8avEDvoPqcO2+/BoJVcP9sjOj4qwJ/wNRWuoA=
 github.com/lyft/flyteidl v0.18.6/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
+github.com/lyft/flyteidl v0.18.10 h1:kM7HKNsv0S9H0nJMPGdTbD53csjc7ueO9eXX+UtZ3fk=
+github.com/lyft/flyteidl v0.18.10/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
 github.com/lyft/flyteplugins v0.5.1/go.mod h1:8zhqFG9BzbHNQGEXzGYltTJLD+KTmQZkanxXgeFI25c=
 github.com/lyft/flytepropeller v0.3.17 h1:a2PVqWjnn8oNEeayAqNizMAtEixl/F3S4vd8z4kbiqI=
 github.com/lyft/flytepropeller v0.3.17/go.mod h1:T8Utxqv7B5USAX9c/Qh0lBbKXHFSgOwwaISOd9h36P4=

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -9,3 +9,5 @@ const (
 	AuditFieldsContextKey contextutils.Key = "audit_fields"
 	PrincipalContextKey   contextutils.Key = "principal"
 )
+
+const MaxResponseStatusBytes = 32000

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -3002,6 +3002,11 @@ func TestCreateSingleTaskExecution(t *testing.T) {
 				Version:      "12345",
 				ResourceType: core.ResourceType_TASK,
 			},
+			AuthRole: &admin.AuthRole{
+				Method: &admin.AuthRole_KubernetesServiceAccount{
+					KubernetesServiceAccount: "foo",
+				},
+			},
 		},
 		Inputs: &core.LiteralMap{
 			Literals: map[string]*core.Literal{

--- a/pkg/manager/impl/project_manager.go
+++ b/pkg/manager/impl/project_manager.go
@@ -70,9 +70,8 @@ func (m *ProjectManager) UpdateProject(ctx context.Context, projectUpdate admin.
 		return nil, err
 	}
 
-	// Run validation on the request, specifically checking for labels, and return err if validation does not succeed.
-	err = validation.ValidateProjectLabels(projectUpdate)
-	if err != nil {
+	// Run validation on the request and return err if validation does not succeed.
+	if err := validation.ValidateProject(projectUpdate); err != nil {
 		return nil, err
 	}
 

--- a/pkg/manager/impl/project_manager_test.go
+++ b/pkg/manager/impl/project_manager_test.go
@@ -47,11 +47,13 @@ func TestListProjects(t *testing.T) {
 	repository := repositoryMocks.NewMockRepository()
 	repository.ProjectRepo().(*repositoryMocks.MockProjectRepo).ListProjectsFunction = func(
 		ctx context.Context, parameter common.SortParameter) ([]models.Project, error) {
+		activeState := int32(admin.Project_ACTIVE)
 		return []models.Project{
 			{
 				Identifier:  "project",
 				Name:        "project",
 				Description: "project_description",
+				State:       &activeState,
 			},
 		}, nil
 	}

--- a/pkg/manager/impl/shared/constants.go
+++ b/pkg/manager/impl/shared/constants.go
@@ -14,10 +14,8 @@ const (
 	RuntimeVersion        = "runtime version"
 	Metadata              = "metadata"
 	TypedInterface        = "typed interface"
-	Container             = "container"
 	Image                 = "image"
 	Limit                 = "limit"
-	Offset                = "offset"
 	Filters               = "filters"
 	ExpectedInputs        = "expected_inputs"
 	FixedInputs           = "fixed_inputs"
@@ -34,7 +32,7 @@ const (
 	UserInputs            = "user_inputs"
 	Attributes            = "attributes"
 	MatchingAttributes    = "matching_attributes"
-	Resourcetype          = "resource_type"
 	// Parent of a node execution in the node executions table
 	ParentID = "parent_id"
+	AuthRole = "auth_role"
 )

--- a/pkg/manager/impl/testutils/repository.go
+++ b/pkg/manager/impl/testutils/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/lyft/flyteadmin/pkg/repositories/models"
+	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/admin"
 
 	"github.com/lyft/flyteadmin/pkg/repositories"
 	repositoryMocks "github.com/lyft/flyteadmin/pkg/repositories/mocks"
@@ -13,7 +14,8 @@ func GetRepoWithDefaultProjectAndErr(err error) repositories.RepositoryInterface
 	repo := repositoryMocks.NewMockRepository()
 	repo.ProjectRepo().(*repositoryMocks.MockProjectRepo).GetFunction = func(
 		ctx context.Context, projectID string) (models.Project, error) {
-		return models.Project{}, err
+		activeState := int32(admin.Project_ACTIVE)
+		return models.Project{State: &activeState}, err
 	}
 	return repo
 }
@@ -22,7 +24,8 @@ func GetRepoWithDefaultProject() repositories.RepositoryInterface {
 	repo := repositoryMocks.NewMockRepository()
 	repo.ProjectRepo().(*repositoryMocks.MockProjectRepo).GetFunction = func(
 		ctx context.Context, projectID string) (models.Project, error) {
-		return models.Project{}, nil
+		activeState := int32(admin.Project_ACTIVE)
+		return models.Project{State: &activeState}, nil
 	}
 	return repo
 }

--- a/pkg/manager/impl/validation/execution_validator_test.go
+++ b/pkg/manager/impl/validation/execution_validator_test.go
@@ -65,6 +65,22 @@ func TestValidateExecInvalidProjectAndDomain(t *testing.T) {
 	assert.EqualError(t, err, "failed to validate that project [project] and domain [domain] are registered, err: [foo]")
 }
 
+func TestValidateSingleTaskExecution(t *testing.T) {
+	request := testutils.GetExecutionRequest()
+	request.Spec.LaunchPlan.ResourceType = core.ResourceType_TASK
+
+	err := ValidateExecutionRequest(context.Background(), request, testutils.GetRepoWithDefaultProject(), execConfig)
+	assert.EqualError(t, err, "missing auth_role")
+
+	request.Spec.AuthRole = &admin.AuthRole{
+		Method: &admin.AuthRole_KubernetesServiceAccount{
+			KubernetesServiceAccount: "foo",
+		},
+	}
+	err = ValidateExecutionRequest(context.Background(), request, testutils.GetRepoWithDefaultProject(), execConfig)
+	assert.Nil(t, err)
+}
+
 func TestGetExecutionInputs(t *testing.T) {
 	executionRequest := testutils.GetExecutionRequest()
 	lpRequest := testutils.GetLaunchPlanRequest()

--- a/pkg/manager/impl/validation/project_validator.go
+++ b/pkg/manager/impl/validation/project_validator.go
@@ -53,11 +53,15 @@ func ValidateProjectLabels(request admin.Project) error {
 // Validates that a specified project and domain combination has been registered and exists in the db.
 func ValidateProjectAndDomain(
 	ctx context.Context, db repositories.RepositoryInterface, config runtimeInterfaces.ApplicationConfiguration, projectID, domainID string) error {
-	_, err := db.ProjectRepo().Get(ctx, projectID)
+	project, err := db.ProjectRepo().Get(ctx, projectID)
 	if err != nil {
 		return errors.NewFlyteAdminErrorf(codes.InvalidArgument,
 			"failed to validate that project [%s] and domain [%s] are registered, err: [%+v]",
 			projectID, domainID, err)
+	}
+	if *project.State != int32(admin.Project_ACTIVE) {
+		return errors.NewFlyteAdminErrorf(codes.InvalidArgument,
+			"project [%s] is not active", projectID)
 	}
 	var validDomain bool
 	domains := config.GetDomainsConfig()

--- a/pkg/manager/impl/validation/project_validator.go
+++ b/pkg/manager/impl/validation/project_validator.go
@@ -3,8 +3,9 @@ package validation
 import (
 	"context"
 
-	"github.com/lyft/flyteadmin/pkg/errors"
 	"github.com/lyft/flyteadmin/pkg/manager/impl/shared"
+
+	"github.com/lyft/flyteadmin/pkg/errors"
 	"github.com/lyft/flyteadmin/pkg/repositories"
 	runtimeInterfaces "github.com/lyft/flyteadmin/pkg/runtime/interfaces"
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/admin"
@@ -15,36 +16,52 @@ import (
 const projectID = "project_id"
 const projectName = "project_name"
 const projectDescription = "project_description"
+const labels = "labels"
+const maxNameLength = 64
 const maxDescriptionLength = 300
+const maxLabelArrayLength = 16
 
 func ValidateProjectRegisterRequest(request admin.ProjectRegisterRequest) error {
 	if request.Project == nil {
 		return shared.GetMissingArgumentError(shared.Project)
 	}
-	if err := ValidateEmptyStringField(request.Project.Id, projectID); err != nil {
+	return ValidateProject(*request.Project)
+}
+
+func ValidateProject(project admin.Project) error {
+	if err := ValidateEmptyStringField(project.Id, projectID); err != nil {
 		return err
 	}
-	if err := ValidateProjectLabels(*request.Project); err != nil {
+	if err := validateProjectLabels(project); err != nil {
 		return err
 	}
-	if errs := validation.IsDNS1123Label(request.Project.Id); len(errs) > 0 {
-		return errors.NewFlyteAdminErrorf(codes.InvalidArgument, "invalid project id [%s]: %v", request.Project.Id, errs)
+	if errs := validation.IsDNS1123Label(project.Id); len(errs) > 0 {
+		return errors.NewFlyteAdminErrorf(codes.InvalidArgument, "invalid project id [%s]: %v", project.Id, errs)
 	}
-	if err := ValidateEmptyStringField(request.Project.Name, projectName); err != nil {
+	if err := ValidateEmptyStringField(project.Name, projectName); err != nil {
 		return err
 	}
-	if err := ValidateMaxLengthStringField(request.Project.Description, projectDescription, maxDescriptionLength); err != nil {
+	if err := ValidateMaxLengthStringField(project.Name, projectName, maxNameLength); err != nil {
 		return err
 	}
-	if request.Project.Domains != nil {
+	if err := ValidateMaxLengthStringField(project.Description, projectDescription, maxDescriptionLength); err != nil {
+		return err
+	}
+	if project.Domains != nil {
 		return errors.NewFlyteAdminError(codes.InvalidArgument,
 			"Domains are currently only set system wide. Please retry without domains included in your request.")
 	}
 	return nil
 }
 
-func ValidateProjectLabels(request admin.Project) error {
-	if err := ValidateProjectLabelsAlphanumeric(request); err != nil {
+func validateProjectLabels(project admin.Project) error {
+	if project.Labels == nil || len(project.Labels.Values) == 0 {
+		return nil
+	}
+	if err := ValidateMaxMapLengthField(project.Labels.Values, labels, maxLabelArrayLength); err != nil {
+		return err
+	}
+	if err := validateProjectLabelsAlphanumeric(project.Labels); err != nil {
 		return err
 	}
 	return nil
@@ -79,11 +96,8 @@ func ValidateProjectAndDomain(
 
 // Given an admin.Project, checks if the project has labels and if it does, checks if the labels are K8s compliant,
 // i.e. alphanumeric + - and _
-func ValidateProjectLabelsAlphanumeric(request admin.Project) error {
-	if request.Labels == nil || len(request.Labels.Values) == 0 {
-		return nil
-	}
-	for key, value := range request.Labels.Values {
+func validateProjectLabelsAlphanumeric(labels *admin.Labels) error {
+	for key, value := range labels.Values {
 		if errs := validation.IsDNS1123Label(key); len(errs) > 0 {
 			return errors.NewFlyteAdminErrorf(codes.InvalidArgument, "invalid label key [%s]: %v", key, errs)
 		}

--- a/pkg/manager/impl/validation/project_validator_test.go
+++ b/pkg/manager/impl/validation/project_validator_test.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"context"
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/lyft/flyteadmin/pkg/manager/impl/testutils"
@@ -68,6 +69,15 @@ func TestValidateProjectRegisterRequest(t *testing.T) {
 			request: admin.ProjectRegisterRequest{
 				Project: &admin.Project{
 					Id:   "proj",
+					Name: "longnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamel",
+				},
+			},
+			expectedError: "project_name cannot exceed 64 characters",
+		},
+		{
+			request: admin.ProjectRegisterRequest{
+				Project: &admin.Project{
+					Id:   "proj",
 					Name: "proj",
 					Domains: []*admin.Domain{
 						{
@@ -93,6 +103,36 @@ func TestValidateProjectRegisterRequest(t *testing.T) {
 			},
 			expectedError: "project_description cannot exceed 300 characters",
 		},
+		{
+			request: admin.ProjectRegisterRequest{
+				Project: &admin.Project{
+					Id:   "proj",
+					Name: "name",
+					Labels: &admin.Labels{
+						Values: map[string]string{
+							"#badkey": "foo",
+							"bar":     "baz",
+						},
+					},
+				},
+			},
+			expectedError: "invalid label key [#badkey]: [a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]",
+		},
+		{
+			request: admin.ProjectRegisterRequest{
+				Project: &admin.Project{
+					Id:   "proj",
+					Name: "name",
+					Labels: &admin.Labels{
+						Values: map[string]string{
+							"foo": ".bad-label-value",
+							"bar": "baz",
+						},
+					},
+				},
+			},
+			expectedError: "invalid label value [.bad-label-value]: [a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]",
+		},
 	}
 
 	for _, val := range testValues {
@@ -100,6 +140,124 @@ func TestValidateProjectRegisterRequest(t *testing.T) {
 			assert.EqualError(t, ValidateProjectRegisterRequest(val.request), val.expectedError)
 		})
 	}
+}
+
+func TestValidateProject_ValidProject(t *testing.T) {
+	assert.Nil(t, ValidateProject(admin.Project{
+		Id:          "proj",
+		Name:        "proj",
+		Description: "An amazing description for this project",
+		Labels: &admin.Labels{
+			Values: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}))
+}
+
+func TestValidateProject(t *testing.T) {
+	type testValue struct {
+		project       admin.Project
+		expectedError string
+	}
+	testValues := []testValue{
+		{
+			project: admin.Project{
+				Name: "proj",
+				Domains: []*admin.Domain{
+					{
+						Id:   "foo",
+						Name: "foo",
+					},
+				},
+			},
+			expectedError: "missing project_id",
+		},
+		{
+			project: admin.Project{
+				Id:   "%)(*&",
+				Name: "proj",
+			},
+			expectedError: "invalid project id [%)(*&]: [a DNS-1123 label must consist of lower case alphanumeric " +
+				"characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or " +
+				"'123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]",
+		},
+		{
+			project: admin.Project{
+				Id: "proj",
+			},
+			expectedError: "missing project_name",
+		},
+		{
+			project: admin.Project{
+				Id:   "proj",
+				Name: "longnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamel",
+			},
+			expectedError: "project_name cannot exceed 64 characters",
+		},
+		{
+			project: admin.Project{
+				Id:   "proj",
+				Name: "proj",
+				Domains: []*admin.Domain{
+					{
+						Id:   "foo",
+						Name: "foo",
+					},
+					{
+						Id: "foo",
+					},
+				},
+			},
+			expectedError: "Domains are currently only set system wide. Please retry without domains included in your request.",
+		},
+		{
+			project: admin.Project{
+				Id:   "proj",
+				Name: "name",
+				// 301 character string
+				Description: "longnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongn",
+			},
+			expectedError: "project_description cannot exceed 300 characters",
+		},
+		{
+			project: admin.Project{
+				Id:   "proj",
+				Name: "name",
+				Labels: &admin.Labels{
+					Values: createLabelsMap(17),
+				},
+			},
+			expectedError: "labels map cannot exceed 16 entries",
+		},
+		{
+			project: admin.Project{
+				Id:   "proj",
+				Name: "name",
+				Labels: &admin.Labels{
+					Values: map[string]string{
+						"#badkey": "foo",
+						"bar":     "baz",
+					},
+				},
+			},
+			expectedError: "invalid label key [#badkey]: [a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]",
+		},
+	}
+
+	for _, val := range testValues {
+		t.Run(val.expectedError, func(t *testing.T) {
+			assert.EqualError(t, ValidateProject(val.project), val.expectedError)
+		})
+	}
+}
+
+func createLabelsMap(size int) map[string]string {
+	result := make(map[string]string, size)
+	for i := 0; i < size; i++ {
+		result["key-"+strconv.Itoa(i)] = "value"
+	}
+	return result
 }
 
 func TestValidateProjectAndDomain(t *testing.T) {

--- a/pkg/manager/impl/validation/validation.go
+++ b/pkg/manager/impl/validation/validation.go
@@ -34,6 +34,14 @@ func ValidateMaxLengthStringField(field string, fieldName string, limit int) err
 	return nil
 }
 
+// Validates that a map field does not exceed a certain amount of entries
+func ValidateMaxMapLengthField(m map[string]string, fieldName string, limit int) error {
+	if len(m) > limit {
+		return errors.NewFlyteAdminErrorf(codes.InvalidArgument, "%s map cannot exceed %d entries", fieldName, limit)
+	}
+	return nil
+}
+
 func ValidateIdentifierFieldsSet(id *core.Identifier) error {
 	if id == nil {
 		return shared.GetMissingArgumentError(shared.ID)

--- a/pkg/manager/impl/validation/validation_test.go
+++ b/pkg/manager/impl/validation/validation_test.go
@@ -25,6 +25,17 @@ func TestValidateMaxLengthStringField(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, err.(errors.FlyteAdminError).Code())
 }
 
+func TestValidateMaxMapLengthField(t *testing.T) {
+	labels := map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+		"k3": "v3",
+	}
+	err := ValidateMaxMapLengthField(labels, "foo", 2)
+	assert.EqualError(t, err, "foo map cannot exceed 2 entries")
+	assert.Equal(t, codes.InvalidArgument, err.(errors.FlyteAdminError).Code())
+}
+
 func TestValidateIdentifier(t *testing.T) {
 	err := ValidateIdentifier(&core.Identifier{
 		ResourceType: core.ResourceType_TASK,

--- a/pkg/repositories/config/migrations.go
+++ b/pkg/repositories/config/migrations.go
@@ -199,7 +199,7 @@ var Migrations = []*gormigrate.Migration{
 			return tx.Exec("ALTER TABLE workflows ADD COLUMN IF NOT EXISTS state integer;").Error
 		},
 	},
-	// Modify the executions & node_executison table, if necessary
+	// Modify the executions & node_execution table, if necessary
 	{
 		ID: "2020-04-29-executions",
 		Migrate: func(tx *gorm.DB) error {

--- a/pkg/repositories/config/migrations.go
+++ b/pkg/repositories/config/migrations.go
@@ -269,4 +269,22 @@ var Migrations = []*gormigrate.Migration{
 			return tx.Model(&TaskExecution{}).RemoveIndex("idx_task_executions_exec").Error
 		},
 	},
+	{
+		ID: "2020-11-03-project-state-addition",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.AutoMigrate(&models.Project{}).Error
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Model(&models.Project{}).DropColumn("state").Error
+		},
+	},
+	{
+		ID: "2020-11-03-project-state-default",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.Exec("UPDATE projects set state = 0").Error
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Exec("UPDATE projects set state = NULL").Error
+		},
+	},
 }

--- a/pkg/repositories/gormimpl/project_repo.go
+++ b/pkg/repositories/gormimpl/project_repo.go
@@ -5,6 +5,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 
+	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/lyft/flytestdlib/promutils"
 
 	"github.com/jinzhu/gorm"
@@ -50,7 +51,7 @@ func (r *ProjectRepo) Get(ctx context.Context, projectID string) (models.Project
 
 func (r *ProjectRepo) ListAll(ctx context.Context, sortParameter common.SortParameter) ([]models.Project, error) {
 	var projects []models.Project
-	var tx = r.db
+	var tx = r.db.Where("state != ?", int32(admin.Project_ARCHIVED))
 	if sortParameter != nil {
 		tx = tx.Order(sortParameter.GetGormOrderExpr())
 	}

--- a/pkg/repositories/gormimpl/project_repo_test.go
+++ b/pkg/repositories/gormimpl/project_repo_test.go
@@ -19,12 +19,14 @@ func TestCreateProject(t *testing.T) {
 
 	query := GlobalMock.NewMock()
 	query.WithQuery(
-		`INSERT INTO "projects" ("created_at","updated_at","deleted_at","identifier","name","description","labels") VALUES (?,?,?,?,?,?,?)`)
+		`INSERT INTO "projects" ("created_at","updated_at","deleted_at","identifier","name","description","labels","state") VALUES (?,?,?,?,?,?,?,?)`)
 
+	activeState := int32(admin.Project_ACTIVE)
 	err := projectRepo.Create(context.Background(), models.Project{
 		Identifier:  "proj",
 		Name:        "proj",
 		Description: "projDescription",
+		State:       &activeState,
 	})
 	assert.NoError(t, err)
 	assert.True(t, query.Triggered)
@@ -38,6 +40,7 @@ func TestGetProject(t *testing.T) {
 	response["identifier"] = "project_id"
 	response["name"] = "project_name"
 	response["description"] = "project_description"
+	response["state"] = admin.Project_ACTIVE
 
 	query := GlobalMock.NewMock()
 	query.WithQuery(`SELECT * FROM "projects"  WHERE "projects"."deleted_at" IS NULL AND ` +
@@ -51,6 +54,7 @@ func TestGetProject(t *testing.T) {
 	assert.Equal(t, "project_id", output.Identifier)
 	assert.Equal(t, "project_name", output.Name)
 	assert.Equal(t, "project_description", output.Description)
+	assert.Equal(t, int32(admin.Project_ACTIVE), *output.State)
 }
 
 func TestListProjects(t *testing.T) {
@@ -60,17 +64,19 @@ func TestListProjects(t *testing.T) {
 	fooProject["identifier"] = "foo"
 	fooProject["name"] = "foo =)"
 	fooProject["description"] = "foo description"
+	fooProject["state"] = admin.Project_ACTIVE
 	projects[0] = fooProject
 
 	barProject := make(map[string]interface{})
 	barProject["identifier"] = "bar"
 	barProject["name"] = "Bar"
 	barProject["description"] = "Bar description"
+	barProject["state"] = admin.Project_ACTIVE
 	projects[1] = barProject
 
 	GlobalMock := mocket.Catcher.Reset()
 	GlobalMock.Logging = true
-	GlobalMock.NewMock().WithQuery(`SELECT * FROM "projects"  WHERE "projects"."deleted_at" IS NULL ORDER BY identifier asc`).
+	GlobalMock.NewMock().WithQuery(`SELECT * FROM "projects"  WHERE "projects"."deleted_at" IS NULL AND ((state != 1)) ORDER BY identifier asc`).
 		WithReply(projects)
 
 	var alphabeticalSortParam, _ = common.NewSortParameter(admin.Sort{
@@ -83,7 +89,27 @@ func TestListProjects(t *testing.T) {
 	assert.Equal(t, "foo", output[0].Identifier)
 	assert.Equal(t, "foo =)", output[0].Name)
 	assert.Equal(t, "foo description", output[0].Description)
+	assert.Equal(t, int32(admin.Project_ACTIVE), *output[0].State)
 	assert.Equal(t, "bar", output[1].Identifier)
 	assert.Equal(t, "Bar", output[1].Name)
 	assert.Equal(t, "Bar description", output[1].Description)
+	assert.Equal(t, int32(admin.Project_ACTIVE), *output[1].State)
+}
+
+func TestUpdateProject(t *testing.T) {
+	projectRepo := NewProjectRepo(GetDbForTest(t), errors.NewTestErrorTransformer(), mockScope.NewTestScope())
+	GlobalMock := mocket.Catcher.Reset()
+
+	query := GlobalMock.NewMock()
+	query.WithQuery(`UPDATE "projects" SET "description" = ?, "identifier" = ?, "name" = ?, "state" = ?, "updated_at" = ?  WHERE "projects"."deleted_at" IS NULL AND "projects"."identifier" = ?`)
+
+	activeState := int32(admin.Project_ACTIVE)
+	err := projectRepo.UpdateProject(context.Background(), models.Project{
+		Identifier:  "project_id",
+		Name:        "project_name",
+		Description: "project_description",
+		State:       &activeState,
+	})
+	assert.Nil(t, err)
+	assert.True(t, query.Triggered)
 }

--- a/pkg/repositories/mocks/project_repo.go
+++ b/pkg/repositories/mocks/project_repo.go
@@ -6,6 +6,7 @@ import (
 	"github.com/lyft/flyteadmin/pkg/common"
 	"github.com/lyft/flyteadmin/pkg/repositories/interfaces"
 	"github.com/lyft/flyteadmin/pkg/repositories/models"
+	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/admin"
 )
 
 type CreateProjectFunction func(ctx context.Context, project models.Project) error
@@ -31,7 +32,11 @@ func (r *MockProjectRepo) Get(ctx context.Context, projectID string) (models.Pro
 	if r.GetFunction != nil {
 		return r.GetFunction(ctx, projectID)
 	}
-	return models.Project{}, nil
+	activeState := int32(admin.Project_ACTIVE)
+	return models.Project{
+		Identifier: projectID,
+		State:      &activeState,
+	}, nil
 }
 
 func (r *MockProjectRepo) ListAll(ctx context.Context, sortParameter common.SortParameter) ([]models.Project, error) {

--- a/pkg/repositories/models/project.go
+++ b/pkg/repositories/models/project.go
@@ -6,4 +6,6 @@ type Project struct {
 	Name        string // Human-readable name, not a unique identifier.
 	Description string `gorm:"type:varchar(300)"`
 	Labels      []byte
+	// GORM doesn't save the zero value for ints, so we use a pointer for the State field
+	State *int32 `gorm:"default:0;index"`
 }

--- a/pkg/repositories/transformers/project.go
+++ b/pkg/repositories/transformers/project.go
@@ -13,6 +13,7 @@ type CreateProjectModelInput struct {
 }
 
 func CreateProjectModel(project *admin.Project) models.Project {
+	stateInt := int32(project.State)
 	projectBytes, err := proto.Marshal(project)
 	if err != nil {
 		return models.Project{}
@@ -22,6 +23,7 @@ func CreateProjectModel(project *admin.Project) models.Project {
 		Name:        project.Name,
 		Description: project.Description,
 		Labels:      projectBytes,
+		State:       &stateInt,
 	}
 }
 
@@ -36,6 +38,7 @@ func FromProjectModel(projectModel models.Project, domains []*admin.Domain) admi
 		Name:        projectModel.Name,
 		Description: projectModel.Description,
 		Labels:      projectDeserialized.Labels,
+		State:       admin.Project_ProjectState(*projectModel.State),
 	}
 	project.Domains = domains
 	return project

--- a/pkg/repositories/transformers/project_test.go
+++ b/pkg/repositories/transformers/project_test.go
@@ -16,8 +16,10 @@ func TestCreateProjectModel(t *testing.T) {
 		Id:          "project_id",
 		Name:        "project_name",
 		Description: "project_description",
+		State:       admin.Project_ACTIVE,
 	})
 
+	activeState := int32(admin.Project_ACTIVE)
 	assert.Equal(t, models.Project{
 		Identifier:  "project_id",
 		Name:        "project_name",
@@ -27,14 +29,17 @@ func TestCreateProjectModel(t *testing.T) {
 			0x6a, 0x65, 0x63, 0x74, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x22, 0x13, 0x70, 0x72, 0x6f, 0x6a, 0x65,
 			0x63, 0x74, 0x5f, 0x64, 0x65, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e,
 		},
+		State: &activeState,
 	}, projectModel)
 }
 
 func TestFromProjectModel(t *testing.T) {
+	activeState := int32(admin.Project_ACTIVE)
 	projectModel := models.Project{
 		Identifier:  "proj_id",
 		Name:        "proj_name",
 		Description: "proj_description",
+		State:       &activeState,
 	}
 	domains := []*admin.Domain{
 		{
@@ -52,20 +57,24 @@ func TestFromProjectModel(t *testing.T) {
 		Name:        "proj_name",
 		Description: "proj_description",
 		Domains:     domains,
+		State:       admin.Project_ACTIVE,
 	}, &project))
 }
 
 func TestFromProjectModels(t *testing.T) {
+	activeState := int32(admin.Project_ACTIVE)
 	projectModels := []models.Project{
 		{
 			Identifier:  "proj1_id",
 			Name:        "proj1_name",
 			Description: "proj1_description",
+			State:       &activeState,
 		},
 		{
 			Identifier:  "proj2_id",
 			Name:        "proj2_name",
 			Description: "proj2_description",
+			State:       &activeState,
 		},
 	}
 	domains := []*admin.Domain{
@@ -84,6 +93,7 @@ func TestFromProjectModels(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("proj%v_id", index+1), project.Id)
 		assert.Equal(t, fmt.Sprintf("proj%v_name", index+1), project.Name)
 		assert.Equal(t, fmt.Sprintf("proj%v_description", index+1), project.Description)
+		assert.Equal(t, admin.Project_ACTIVE, project.State)
 		assert.EqualValues(t, domains, project.Domains)
 	}
 }

--- a/pkg/rpc/adminservice/base.go
+++ b/pkg/rpc/adminservice/base.go
@@ -89,7 +89,7 @@ func NewAdminServer(kubeConfig, master string) *AdminService {
 		applicationConfiguration.RoleNameKey,
 		execCluster,
 		adminScope.NewSubScope("executor").NewSubScope("flytepropeller"),
-		configuration.NamespaceMappingConfiguration())
+		configuration.NamespaceMappingConfiguration(), applicationConfiguration.EventVersion)
 	logger.Info(context.Background(), "Successfully created a workflow executor engine")
 	dataStorageClient, err := storage.NewDataStore(storeConfig, adminScope.NewSubScope("storage"))
 	if err != nil {

--- a/pkg/rpc/adminservice/tests/execution_test.go
+++ b/pkg/rpc/adminservice/tests/execution_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	flyteAdminErrors "github.com/lyft/flyteadmin/pkg/errors"
+	"google.golang.org/grpc/codes"
+
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
 
 	"github.com/golang/protobuf/proto"
@@ -178,7 +181,8 @@ func TestCreateWorkflowEventErr(t *testing.T) {
 			Phase:       core.WorkflowExecution_RUNNING,
 		},
 	})
-	assert.EqualError(t, err, "rpc error: code = Internal desc = expected error")
+	assert.EqualError(t, err, "expected error")
+	assert.Equal(t, codes.Internal, err.(flyteAdminErrors.FlyteAdminError).Code())
 	assert.Nil(t, resp)
 }
 
@@ -220,7 +224,7 @@ func TestGetExecutionError(t *testing.T) {
 	actualResponse, err := mockServer.GetExecution(context.Background(), &admin.WorkflowExecutionGetRequest{
 		Id: &workflowExecutionIdentifier,
 	})
-	assert.EqualError(t, err, "rpc error: code = Internal desc = expected error")
+	assert.EqualError(t, err, "expected error")
 	assert.Nil(t, actualResponse)
 }
 
@@ -273,7 +277,8 @@ func TestListExecutionsError(t *testing.T) {
 		},
 		Limit: 1,
 	})
-	assert.EqualError(t, err, "rpc error: code = Internal desc = expected error")
+	assert.EqualError(t, err, "expected error")
+	assert.Equal(t, codes.Internal, err.(flyteAdminErrors.FlyteAdminError).Code())
 	assert.Nil(t, response)
 }
 
@@ -320,6 +325,7 @@ func TestTerminateExecution_Error(t *testing.T) {
 		Id:    &identifier,
 		Cause: abortCause,
 	})
-	assert.EqualError(t, err, "rpc error: code = Internal desc = expected error")
+	assert.EqualError(t, err, "expected error")
+	assert.Equal(t, codes.Internal, err.(flyteAdminErrors.FlyteAdminError).Code())
 	assert.Nil(t, response)
 }

--- a/pkg/rpc/adminservice/tests/node_execution_test.go
+++ b/pkg/rpc/adminservice/tests/node_execution_test.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"testing"
 
+	flyteAdminErrors "github.com/lyft/flyteadmin/pkg/errors"
+	"google.golang.org/grpc/codes"
+
 	"github.com/golang/protobuf/proto"
 
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
@@ -68,7 +71,8 @@ func TestCreateNodeEventErr(t *testing.T) {
 			Phase: core.NodeExecution_SKIPPED,
 		},
 	})
-	assert.EqualError(t, err, "rpc error: code = Internal desc = expected error")
+	assert.EqualError(t, err, "expected error")
+	assert.Equal(t, codes.Internal, err.(flyteAdminErrors.FlyteAdminError).Code())
 	assert.Nil(t, resp)
 }
 
@@ -111,7 +115,8 @@ func TestGetNodeExecutionError(t *testing.T) {
 	actualResponse, err := mockServer.GetNodeExecution(context.Background(), &admin.NodeExecutionGetRequest{
 		Id: &nodeExecutionID,
 	})
-	assert.EqualError(t, err, "rpc error: code = Internal desc = expected error")
+	assert.EqualError(t, err, "expected error")
+	assert.Equal(t, codes.Internal, err.(flyteAdminErrors.FlyteAdminError).Code())
 	assert.Nil(t, actualResponse)
 }
 
@@ -160,7 +165,8 @@ func TestListNodeExecutionsError(t *testing.T) {
 		Limit: 1,
 		Token: "20",
 	})
-	assert.EqualError(t, err, "rpc error: code = Internal desc = expected error")
+	assert.EqualError(t, err, "expected error")
+	assert.Equal(t, codes.Internal, err.(flyteAdminErrors.FlyteAdminError).Code())
 	assert.Nil(t, response)
 }
 
@@ -211,7 +217,8 @@ func TestListNodeExecutionsForTaskError(t *testing.T) {
 		Limit: 1,
 		Token: "20",
 	})
-	assert.EqualError(t, err, "rpc error: code = Internal desc = expected error")
+	assert.EqualError(t, err, "expected error")
+	assert.Equal(t, codes.Internal, err.(flyteAdminErrors.FlyteAdminError).Code())
 	assert.Nil(t, response)
 }
 

--- a/pkg/rpc/adminservice/tests/task_execution_test.go
+++ b/pkg/rpc/adminservice/tests/task_execution_test.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"testing"
 
+	"google.golang.org/grpc/codes"
+
 	"github.com/golang/protobuf/proto"
+	flyteAdminErrors "github.com/lyft/flyteadmin/pkg/errors"
 	"github.com/lyft/flyteadmin/pkg/manager/mocks"
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
@@ -177,7 +180,8 @@ func TestTaskExecution(t *testing.T) {
 				RetryAttempt:    retryAttempt,
 			},
 		})
-		assert.EqualError(t, err, "rpc error: code = Internal desc = expected error")
+		assert.EqualError(t, err, "expected error")
+		assert.Equal(t, codes.Internal, err.(flyteAdminErrors.FlyteAdminError).Code())
 		assert.Nil(t, resp)
 	})
 

--- a/pkg/rpc/adminservice/util/transformers.go
+++ b/pkg/rpc/adminservice/util/transformers.go
@@ -1,20 +1,25 @@
 package util
 
 import (
+	"github.com/lyft/flyteadmin/pkg/common"
 	"github.com/lyft/flyteadmin/pkg/errors"
 
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
-// Transforms errors to grpc-compatible error types.
+// Transforms errors to grpc-compatible error types and optionally truncates it if necessary.
 func TransformAndRecordError(err error, metrics *RequestMetrics) error {
-	switch err := err.(type) {
-	case errors.FlyteAdminError:
-		metrics.Record(err.(errors.FlyteAdminError).Code())
-		return err
-	default:
-		metrics.Record(codes.Internal)
-		return status.Error(codes.Internal, err.Error())
+	var errorMessage = err.Error()
+	concatenateErrMessage := false
+	if len(errorMessage) > common.MaxResponseStatusBytes {
+		errorMessage = err.Error()[:common.MaxResponseStatusBytes]
+		concatenateErrMessage = true
 	}
+	if flyteAdminError, ok := err.(errors.FlyteAdminError); !ok {
+		err = errors.NewFlyteAdminError(codes.Internal, errorMessage)
+	} else if concatenateErrMessage {
+		err = errors.NewFlyteAdminError(flyteAdminError.Code(), errorMessage)
+	}
+	metrics.Record(err.(errors.FlyteAdminError).Code())
+	return err
 }

--- a/pkg/rpc/adminservice/util/transformers_test.go
+++ b/pkg/rpc/adminservice/util/transformers_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/lyft/flyteadmin/pkg/common"
+
 	adminErrors "github.com/lyft/flyteadmin/pkg/errors"
 	mockScope "github.com/lyft/flytestdlib/promutils"
 	"github.com/stretchr/testify/assert"
@@ -37,4 +39,15 @@ func TestTransformError_BasicError(t *testing.T) {
 	transormerStatus, ok := status.FromError(transformedError)
 	assert.True(t, ok)
 	assert.Equal(t, codes.Internal, transormerStatus.Code())
+}
+
+func TestTruncateErrorMessage(t *testing.T) {
+	errorMessage := make([]byte, common.MaxResponseStatusBytes+1)
+	for i := 0; i <= common.MaxResponseStatusBytes; i++ {
+		errorMessage[i] = byte('a')
+	}
+
+	err := adminErrors.NewFlyteAdminError(codes.InvalidArgument, string(errorMessage))
+	transformedError := TransformAndRecordError(err, &testRequestMetrics)
+	assert.Len(t, transformedError.Error(), common.MaxResponseStatusBytes)
 }

--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -48,6 +48,8 @@ type ApplicationConfig struct {
 	// This defines the nested path on the configured external storage provider where workflow closures are remotely
 	// offloaded.
 	MetadataStoragePrefix []string `json:"metadataStoragePrefix"`
+	// Event version to be used for Flyte workflows
+	EventVersion int `json:"eventVersion"`
 }
 
 // This section holds common config for AWS

--- a/pkg/workflowengine/impl/propeller_executor.go
+++ b/pkg/workflowengine/impl/propeller_executor.go
@@ -44,6 +44,7 @@ type FlytePropeller struct {
 	roleNameKey      string
 	metrics          propellerMetrics
 	config           runtimeInterfaces.NamespaceMappingConfiguration
+	eventVersion     v1alpha1.EventVersion
 }
 
 type FlyteWorkflowBuilder struct{}
@@ -138,6 +139,10 @@ func (c *FlytePropeller) ExecuteWorkflow(ctx context.Context, input interfaces.E
 	flyteWf.Labels = labels
 	annotations := addMapValues(input.Annotations, flyteWf.Annotations)
 	flyteWf.Annotations = annotations
+	if flyteWf.WorkflowMeta == nil {
+		flyteWf.WorkflowMeta = &v1alpha1.WorkflowMeta{}
+	}
+	flyteWf.WorkflowMeta.EventVersion = c.eventVersion
 	addExecutionOverrides(input.TaskPluginOverrides, flyteWf)
 
 	if input.Reference.Spec.RawOutputDataConfig != nil {
@@ -301,7 +306,7 @@ func newPropellerMetrics(scope promutils.Scope) propellerMetrics {
 }
 
 func NewFlytePropeller(roleNameKey string, executionCluster interfaces2.ClusterInterface,
-	scope promutils.Scope, configuration runtimeInterfaces.NamespaceMappingConfiguration) interfaces.Executor {
+	scope promutils.Scope, configuration runtimeInterfaces.NamespaceMappingConfiguration, eventVersion int) interfaces.Executor {
 
 	return &FlytePropeller{
 		executionCluster: executionCluster,
@@ -309,5 +314,6 @@ func NewFlytePropeller(roleNameKey string, executionCluster interfaces2.ClusterI
 		roleNameKey:      roleNameKey,
 		metrics:          newPropellerMetrics(scope),
 		config:           configuration,
+		eventVersion:     v1alpha1.EventVersion(eventVersion),
 	}
 }


### PR DESCRIPTION
# TL;DR
Increase the validation done on `CreateProject` and `UpdateProject` in `project_manager.go`

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Increase the validation done on `CreateProject` and `UpdateProject` in `project_manager.go`:
* Validate `admin.Project` on `UpdateProject`
* Add length validation for `project-name`. It cannot contain more than 64 characters
* Add validation for number entries in `labels`. It cannot contain more than 16 labels

## Tracking Issue
https://github.com/lyft/flyte/issues/336

## Follow-up issue
_NA_
